### PR TITLE
Added compose v2 syntax compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Check for docker/podman
 DOCKER := $(shell command -v podman 2> /dev/null || command -v docker 2> /dev/null)
 
-# Check for docker-compose/podman-compose
-DOCKER_COMPOSE := $(shell command -v podman-compose 2> /dev/null || command -v docker-compose 2> /dev/null)
+# Check for docker-compose/podman-compose or docker compose
+DOCKER_COMPOSE := $(shell command -v podman-compose 2> /dev/null || command -v docker-compose 2> /dev/null || (command -v docker > /dev/null 2>&1 && docker compose version > /dev/null 2>&1 && echo "docker compose"))
 
 .PHONY: info
 info:
@@ -14,7 +14,7 @@ else
 endif
 
 ifeq ($(DOCKER_COMPOSE),)
-	@echo "Neither docker-compose nor podman-compose is installed."
+	@echo "Neither docker-compose, docker compose, nor podman-compose is installed."
 	exit 1
 else
 	@echo "Using $(DOCKER_COMPOSE)"
@@ -23,15 +23,22 @@ endif
 # Start the containers
 .PHONY: compose-up
 compose-up:
+ifeq ($(DOCKER_COMPOSE),docker compose)
+	$(DOCKER) compose -f deploy/dev/docker-compose.yml up -d
+else
 	$(DOCKER_COMPOSE) --file deploy/dev/docker-compose.yml up -d
+endif
 
 # Stop the containers
 .PHONY: compose-down
 compose-down:
+ifeq ($(DOCKER_COMPOSE),docker compose)
+	$(DOCKER) compose -f deploy/dev/docker-compose.yml down
+else
 	$(DOCKER_COMPOSE) --file deploy/dev/docker-compose.yml down
+endif
 
 # Get container ID
-.PHONY: $(FPM_ID)
 FPM_ID = $(shell $(DOCKER) ps | grep 'quay.io/kissj/php-ubi' | awk '{print $$1}')
 
 .PHONY: composer-install
@@ -42,7 +49,7 @@ composer-install:
 migrate:
 	$(DOCKER) exec -it -u root $(FPM_ID) sh -c "COMPOSER_ALLOW_SUPERUSER=1 composer phinx:migrate --no-interaction"
 
-
 dev-up: info compose-up composer-install migrate
-dev-down: info compose-down
 
+.PHONY: dev-down
+dev-down: info compose-down


### PR DESCRIPTION
This PR provides compatibility with integrated "docker-compose" tool since Compose V2 as explained here https://docs.docker.com/compose/releases/migrate

Running the makefile now checks whether legacy docker installation is available or compose v2 compatible Docker is installed.