### PR TITLE
added tshirt size column to patrol roster pdf

### DIFF
--- a/src/Export/ExportController.php
+++ b/src/Export/ExportController.php
@@ -134,7 +134,7 @@ class ExportController extends AbstractController
             return $this->redirect($request, $response, 'dashboard');
         }
 
-        $patrolsRoster = $this->participantRepository->getPatrolsRoster($event);
+        $patrolsRoster = $this->participantRepository->getPatrolsRoster($event, $this->translator);
 
         return $this->streamPdf($response, $this->pdfGenerator->generatePatrolRoster(
             $event,

--- a/src/Participant/ParticipantRepository.php
+++ b/src/Participant/ParticipantRepository.php
@@ -662,7 +662,7 @@ class ParticipantRepository extends Repository
         );
     }
 
-    public function getPatrolsRoster(Event $event): PatrolsRoster
+    public function getPatrolsRoster(Event $event, TranslatorInterface $translator): PatrolsRoster
     {
         $singlePatrolsRoster = [];
 
@@ -674,8 +674,12 @@ class ParticipantRepository extends Repository
                 $pl->patrolName ?? '',
                 $pl->contingent ?? '',
                 $pl->getFullName(),
+                EntryParticipant::tshirtSizeFromRaw($pl->getTshirtSize(), $translator),
                 array_map(
-                    fn (PatrolParticipant $pp): string => $pp->getFullName(),
+                    fn (PatrolParticipant $pp): array => [
+                        'name' => $pp->getFullName(),
+                        'tshirtSize' => EntryParticipant::tshirtSizeFromRaw($pp->getTshirtSize(), $translator),
+                    ],
                     $pl->patrolParticipants,
                 ),
             );

--- a/src/Participant/Patrol/SinglePatrolRoster.php
+++ b/src/Participant/Patrol/SinglePatrolRoster.php
@@ -7,14 +7,15 @@ namespace kissj\Participant\Patrol;
 readonly class SinglePatrolRoster
 {
     /**
-     * @param array<string> $patrolParticipantNames
+     * @param array<array{name: string, tshirtSize: string|null}> $patrolParticipants
      */
     public function __construct(
         public string $patrolId,
         public string $patrolName,
         public string $contingent,
         public string $patrolLeaderName,
-        public array $patrolParticipantNames,
+        public ?string $patrolLeaderTshirtSize,
+        public array $patrolParticipants,
     ) {
     }
 }

--- a/src/PdfGenerator/mPdfGenerator.php
+++ b/src/PdfGenerator/mPdfGenerator.php
@@ -82,6 +82,7 @@ class mPdfGenerator extends PdfGenerator
         $templateData = [
             'event' => $event,
             'patrolsRoster' => $patrolsRoster,
+            'rosterCss' => $this->getRosterFullCss(),
         ];
 
         return $this->writeHtmlToPdf($templateName, $templateData, 'roster');
@@ -164,6 +165,18 @@ class mPdfGenerator extends PdfGenerator
             if ($overrideCss !== false) {
                 $css .= "\n" . $overrideCss;
             }
+        }
+
+        return $css;
+    }
+
+    private function getRosterFullCss(): string
+    {
+        $css = '';
+
+        $pdfCss = file_get_contents(__DIR__ . '/../../public/stylesPdf.css');
+        if ($pdfCss !== false) {
+            $css = $pdfCss;
         }
 
         return $css;

--- a/src/Templates/cs.yaml
+++ b/src/Templates/cs.yaml
@@ -626,6 +626,7 @@ receipt:
 roster:
     perex: "Tímto dokumentem potvrzuji, že souhlasím s pravidly akce."
     name: "Jméno účastníka"
+    tshirt: "Tričko"
     signature: "Podpis účastníka"
 badges:
     back: "Zpět"

--- a/src/Templates/en.yaml
+++ b/src/Templates/en.yaml
@@ -618,6 +618,7 @@ receipt:
 roster:
     perex: "By singing this document you hereby agree with the presented rules of the event."
     name: "Name of the participant"
+    tshirt: "T-shirt"
     signature: "Signature of the participant"
 badges:
     back: "Back"

--- a/src/Templates/sk.yaml
+++ b/src/Templates/sk.yaml
@@ -618,6 +618,7 @@ receipt:
 roster:
     perex: "Týmto dokumentom potvrdzujem, že súhlasím s pravidlami akcie."
     name: "Meno účastníka"
+    tshirt: "Tričko"
     signature: "Podpis účastníka"
 badges:
     back: "Späť"

--- a/src/Templates/translatable/_layoutPdfRoster.twig
+++ b/src/Templates/translatable/_layoutPdfRoster.twig
@@ -10,7 +10,7 @@
     <style>{{ rosterCss|default('')|raw }}</style>
 </head>
 
-<body class="wrapper">
+<body>
     {% block content %}{% endblock %}
 </body>
 </html>

--- a/src/Templates/translatable/_layoutPdfRoster.twig
+++ b/src/Templates/translatable/_layoutPdfRoster.twig
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="{{ locale|default('cs') }}">
+
+<head>
+    <meta charset="utf-8"/>
+    <meta name="robots" content="noindex, nofollow">
+
+    <title>{{ '_layout.title' | trans }} - {{ event.readableName }} - kissj</title>
+
+    <style>{{ rosterCss|default('')|raw }}</style>
+</head>
+
+<body class="wrapper">
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/src/Templates/translatable/roster/roster.twig
+++ b/src/Templates/translatable/roster/roster.twig
@@ -1,4 +1,4 @@
-{% extends "_layoutPdf.twig" %}
+{% extends "_layoutPdfRoster.twig" %}
 
 {% block content %}
     {% for patrol in patrolsRoster.patrolsRoster %}
@@ -17,22 +17,26 @@
                 <thead>
                     <tr>
                         <td class="header">{{ 'roster.name'|trans }}</td>
+                        <td class="header">{{ 'roster.tshirt'|trans }}</td>
                         <td class="header">{{ 'roster.signature'|trans }}</td>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <td>{{ patrol.patrolLeaderName }}</td>
+                        <td>{{ patrol.patrolLeaderTshirtSize }}</td>
                         <td></td>
                     </tr>
-                    {% for participantName in patrol.patrolParticipantNames %}
+                    {% for participant in patrol.patrolParticipants %}
                         <tr>
-                            <td>{{ participantName }}</td>
+                            <td>{{ participant.name }}</td>
+                            <td>{{ participant.tshirtSize }}</td>
                             <td></td>
                         </tr>
                     {% endfor %}
                     <!-- empty row for extras -->
                     <tr>
+                        <td></td>
                         <td></td>
                         <td></td>
                     </tr>

--- a/tests/Functional/DealTest.php
+++ b/tests/Functional/DealTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Functional;
 

--- a/tests/Functional/PatrolRosterTest.php
+++ b/tests/Functional/PatrolRosterTest.php
@@ -9,7 +9,9 @@ use kissj\Participant\ParticipantRepository;
 use kissj\Participant\Patrol\PatrolLeaderRepository;
 use kissj\Participant\Patrol\PatrolParticipant;
 use kissj\Participant\Patrol\PatrolParticipantRepository;
+use kissj\Participant\Patrol\PatrolsRoster;
 use kissj\Participant\Patrol\SinglePatrolRoster;
+use kissj\PdfGenerator\PdfGenerator;
 use kissj\User\UserRepository;
 use kissj\User\UserService;
 use kissj\User\UserStatus;
@@ -77,5 +79,29 @@ class PatrolRosterTest extends AppTestCase
 
         self::assertSame('M (střední)', $sizesByName['With Shirt']);
         self::assertNull($sizesByName['Without Shirt']);
+    }
+
+    public function testGeneratePatrolRosterPdfRendersWithTshirtColumn(): void
+    {
+        $app = $this->getTestApp();
+        $eventRepository = $this->getService($app, EventRepository::class);
+        $pdfGenerator = $this->getService($app, PdfGenerator::class);
+
+        $event = $eventRepository->get(1);
+        $roster = new PatrolsRoster([
+            new SinglePatrolRoster('1', 'Roster pdf patrol', '', 'Roster Leader', 'XL (větší)', [
+                ['name' => 'With Shirt', 'tshirtSize' => 'M (střední)'],
+                ['name' => 'Without Shirt', 'tshirtSize' => null],
+            ]),
+            new SinglePatrolRoster('2', 'Roster pdf patrol two', '', 'Second Leader', null, []),
+        ]);
+
+        $pdfBytes = $pdfGenerator->generatePatrolRoster(
+            $event,
+            $roster,
+            $event->eventType->getRosterTemplateName(),
+        );
+
+        self::assertStringStartsWith('%PDF', $pdfBytes);
     }
 }

--- a/tests/Functional/PatrolRosterTest.php
+++ b/tests/Functional/PatrolRosterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Functional;
+
+use kissj\Event\EventRepository;
+use kissj\Participant\ParticipantRepository;
+use kissj\Participant\Patrol\PatrolLeaderRepository;
+use kissj\Participant\Patrol\PatrolParticipant;
+use kissj\Participant\Patrol\PatrolParticipantRepository;
+use kissj\Participant\Patrol\SinglePatrolRoster;
+use kissj\User\UserRepository;
+use kissj\User\UserService;
+use kissj\User\UserStatus;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Tests\AppTestCase;
+
+class PatrolRosterTest extends AppTestCase
+{
+    private const string PATROL_NAME = 'roster tshirt test patrol';
+
+    public function testGetPatrolsRosterCarriesTranslatedTshirtSizes(): void
+    {
+        $app = $this->getTestApp();
+        $userService = $this->getService($app, UserService::class);
+        $userRepository = $this->getService($app, UserRepository::class);
+        $eventRepository = $this->getService($app, EventRepository::class);
+        $patrolLeaderRepository = $this->getService($app, PatrolLeaderRepository::class);
+        $patrolParticipantRepository = $this->getService($app, PatrolParticipantRepository::class);
+        $participantRepository = $this->getService($app, ParticipantRepository::class);
+        $translator = $this->getService($app, TranslatorInterface::class);
+
+        $event = $eventRepository->get(1);
+
+        $user = $userService->registerEmailUser('roster-tshirt-test@example.com', $event);
+        $participant = $userService->createParticipantSetRole($user, 'pl');
+        $patrolLeader = $patrolLeaderRepository->get($participant->id);
+        $patrolLeader->patrolName = self::PATROL_NAME;
+        $patrolLeader->firstName = 'Roster';
+        $patrolLeader->lastName = 'Leader';
+        $patrolLeader->setTshirt('detail.tshirtGenderMale', 'detail.tshirtXL');
+        $patrolLeaderRepository->persist($patrolLeader);
+
+        $participantWithShirt = new PatrolParticipant();
+        $participantWithShirt->patrolLeader = $patrolLeader;
+        $participantWithShirt->firstName = 'With';
+        $participantWithShirt->lastName = 'Shirt';
+        $participantWithShirt->setTshirt('detail.tshirtGenderFemale', 'detail.tshirtM');
+        $patrolParticipantRepository->persist($participantWithShirt);
+
+        $participantWithoutShirt = new PatrolParticipant();
+        $participantWithoutShirt->patrolLeader = $patrolLeader;
+        $participantWithoutShirt->firstName = 'Without';
+        $participantWithoutShirt->lastName = 'Shirt';
+        $patrolParticipantRepository->persist($participantWithoutShirt);
+
+        $user->status = UserStatus::Paid;
+        $userRepository->persist($user);
+
+        $roster = $participantRepository->getPatrolsRoster($event, $translator);
+
+        $ourPatrol = null;
+        foreach ($roster->patrolsRoster as $singlePatrolRoster) {
+            if ($singlePatrolRoster->patrolName === self::PATROL_NAME) {
+                $ourPatrol = $singlePatrolRoster;
+            }
+        }
+
+        self::assertInstanceOf(SinglePatrolRoster::class, $ourPatrol);
+        self::assertSame('XL (větší)', $ourPatrol->patrolLeaderTshirtSize);
+
+        $sizesByName = [];
+        foreach ($ourPatrol->patrolParticipants as $rosterParticipant) {
+            $sizesByName[$rosterParticipant['name']] = $rosterParticipant['tshirtSize'];
+        }
+
+        self::assertSame('M (střední)', $sizesByName['With Shirt']);
+        self::assertNull($sizesByName['Without Shirt']);
+    }
+}


### PR DESCRIPTION
## Summary
- patrol roster PDF export now shows each person's t-shirt size in a new column between name and signature (`Tričko` / `T-shirt`), empty when the participant has none
- sizes are resolved in PHP via the existing `EntryParticipant::tshirtSizeFromRaw()` (same precedent as the entry endpoints, incl. missing-translation fallback); the template stays dumb
- roster PDF layout switched to a new `_layoutPdfRoster.twig` with inlined `stylesPdf.css`, mirroring the existing `_layoutPdfBadge.twig` pattern (`base_path()` external stylesheets never worked in the mPDF context)
- translations added to all three locale files, grouped inside the `roster:` block

## Testing
- new `PatrolRosterTest`: repository returns translated sizes (leader, participant, and null for no shirt, dev-DB-safe pattern) + PDF render smoke test asserting `%PDF` output
- full suite green (262 tests / 1211 assertions); PHPStan level 10 clean except the 2 pre-existing DealTest errors that exist identically on master; CS clean
- runtime-verified against the dev stack: admin roster export for `test-slug` renders all 27 patrols with the new column

🤖 Generated with [Claude Code](https://claude.com/claude-code)