### PR TITLE
wrapped long uploaded file names so they stop breaking the layout

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -474,6 +474,11 @@ tr:nth-child(even) {
 	color: var(--color-grey);
 }
 
+.text-break {
+	overflow-wrap: anywhere;
+	word-break: break-word;
+}
+
 .skautis-member-disabled {
 	color: var(--color-grey);
 	font-weight: bold;

--- a/src/Templates/translatable/widgets/formFields.twig
+++ b/src/Templates/translatable/widgets/formFields.twig
@@ -101,7 +101,7 @@
             {% if value %}
                 {% set storedFilename = personDetails.getUploadedFilename(item.slug) %}
                 <b>
-                    <a target="_blank" href="{{ url_for('show-file', {'filename': storedFilename, 'eventSlug': event.slug}) }}">
+                    <a class="text-break" target="_blank" href="{{ url_for('show-file', {'filename': storedFilename, 'eventSlug': event.slug}) }}">
                         {{ value }}
                     </a>
                     {{ 'detail.uploadedFileSuccessful' | trans }}
@@ -224,7 +224,7 @@
         {{ item.label|trans }}:
         {% set filename = person.getUploadedFilename(item.slug) %}
         {% if filename %}
-            <a target="_blank"
+            <a class="text-break" target="_blank"
                href="{{ url_for('show-file', {'filename': filename, 'eventSlug': event.slug}) }}">
                 {{ value }}
             </a>


### PR DESCRIPTION
added a .text-break utility class into styles.css and applied it to both uploaded-file links in formFields.twig, so long file names wrap instead of overflowing and breaking the admin detail layout

closes #215